### PR TITLE
feat: create invoices and delivery notes whenever an order is created / updated respectively

### DIFF
--- a/parsimony_woo/hook_events/item.py
+++ b/parsimony_woo/hook_events/item.py
@@ -1,0 +1,14 @@
+import frappe
+
+
+def set_valuation_rate(item_doc, item_data):
+	# process valuation rate for the item using a third-party plugin
+	# https://wordpress.org/plugins/cost-of-goods-for-woocommerce/
+
+	metadata = item_data.get("meta_data", [])
+	for data in metadata:
+		if data.get("key") == "_alg_wc_cog_item_cost":
+			# TODO: change the valuation rate to a different default
+			item_doc.valuation_rate = data.get("value", 0.01)
+
+	return item_doc

--- a/parsimony_woo/hooks.py
+++ b/parsimony_woo/hooks.py
@@ -90,6 +90,10 @@ doc_events = {
 	}
 }
 
+woocommerce_postprocess = {
+	"Item": ["parsimony_woo.hook_events.item.set_valuation_rate"]
+}
+
 # Scheduled Tasks
 # ---------------
 

--- a/parsimony_woo/woocommerce/api.py
+++ b/parsimony_woo/woocommerce/api.py
@@ -1,7 +1,10 @@
+import json
 
 from woocommerce import API
 
 import frappe
+from erpnext.erpnext_integrations.connectors.woocommerce_connection import order, verify_request
+from erpnext.selling.doctype.sales_order.sales_order import make_delivery_note, make_sales_invoice
 
 
 def get_woocommerce_client():
@@ -18,3 +21,67 @@ def get_woocommerce_client():
 		version="wc/v3",
 		verify_ssl=False
 	)
+
+
+@frappe.whitelist(allow_guest=True)
+def create_order(*args, **kwargs):
+	# let ERPNext process the request and create an order
+	order(*args, **kwargs)
+
+	try:
+		# auto-create an invoice for the new order
+		_create_invoice(*args, **kwargs)
+	except Exception:
+		error_message = frappe.get_traceback() + "\n\n Request Data: \n" + json.loads(frappe.request.data).__str__()
+		frappe.log_error(error_message, "WooCommerce Create Invoice Error")
+		raise
+
+
+@frappe.whitelist(allow_guest=True)
+def update_order(*args, **kwargs):
+	try:
+		_update_order(*args, **kwargs)
+	except Exception:
+		error_message = frappe.get_traceback() + "\n\n Request Data: \n" + json.loads(frappe.request.data).__str__()
+		frappe.log_error(error_message, "WooCommerce Update Order Error")
+		raise
+
+
+def _create_invoice(*args, **kwargs):
+	order = frappe.get_last_doc("Sales Order")
+	invoice = make_sales_invoice(order.name, ignore_permissions=True)
+	invoice.save()
+	invoice.submit()
+
+
+def _update_order(*args, **kwargs):
+	if frappe.request and frappe.request.data:
+		verify_request()
+		try:
+			order = json.loads(frappe.request.data)
+		except ValueError:
+			# woocommerce returns 'webhook_id=value' for the first request which is not JSON
+			order = frappe.request.data
+		event = frappe.get_request_header("X-Wc-Webhook-Event")
+	else:
+		return "success"
+
+	if event == "updated":
+		sales_order = frappe.db.exists("Sales Order", {"woocommerce_id": order.get("id")})
+		if not sales_order:
+			return "success"
+
+		# if a Woocommerce order is processing, then it has been shipped, but not fulfilled yet
+		# ref: https://docs.woocommerce.com/document/managing-orders/#section-21
+		if order.get("status") == "processing":
+			existing_deliveries = frappe.get_all("Delivery Note Item",
+				filters={"docstatus": 1, "against_sales_order": sales_order},
+				fields=["parent"],
+				distinct=True)
+
+			if existing_deliveries:
+				return "success"
+
+			delivery_note = make_delivery_note(sales_order)
+			delivery_note.save()
+			delivery_note.submit()


### PR DESCRIPTION
## Dependencies

- Requires https://github.com/ParsimonyGit/erpnext/pull/2.
- Install and activate the following helper plugin to enable Cost of Goods Sold (COGS) for your WooCommerce products and use that for Valuation Rate (mandatory for sales transactions) - https://wordpress.org/plugins/cost-of-goods-for-woocommerce/

## Changes

- [x] Whenever an order is created on WooCommerce, a Sales Invoice is created on Parsimony against the sales order created by ERPNext.
- [x] Whenever a WooCommerce order's status changes to ["Processing"](https://docs.woocommerce.com/document/managing-orders/#section-21), create a delivery note for the linked order.

## Setup

In your WooCommerce site, setup 2 webhooks for the following actions:

- **Common webhook options:**
  - **Secret:** Use [this guide](https://docs.erpnext.com/docs/user/manual/en/erpnext_integration/woocommerce_integration) to generate one
  - **API Version:** WP REST API Integration v3
- **Order created**
  - **Name:** The name of the webhook (for your reference)
  - **Status:** One of Active, Paused or Disabled
  - **Topic:** Order created
  - **Delivery URL:** Link to the webhook endpoint, formatted with your Parsimony site using `https://<site_url>/api/method/parsimony_woo.woocommerce.api.create_order`
- **Order updated**
  - **Name:** The name of the webhook (for your reference)
  - **Status:** One of Active, Paused or Disabled
  - **Topic:** Order updated
  - **Delivery URL:** Link to the webhook endpoint, formatted with your Parsimony site using `https://<site_url>/api/method/parsimony_woo.woocommerce.api.update_order`